### PR TITLE
docs: remove infos about avx for immich:noml

### DIFF
--- a/unraid/immich.xml
+++ b/unraid/immich.xml
@@ -18,7 +18,7 @@
     </Branch>
     <Branch>
         <Tag>noml</Tag>
-        <TagDescription>Latest Immich release with an Alpine base. Machine-learning is completly removed. (tinnny image), use this if your CPU does not support AVX</TagDescription>
+        <TagDescription>Latest Immich release with an Alpine base. Machine-learning is completly removed (tinnny image).</TagDescription>
         <ReadMe>https://github.com/imagegenius/docker-immich/tree/noml#readme</ReadMe>
         <GitHub>https://github.com/imagegenius/docker-immich/tree/noml#application-setup</GitHub>
     </Branch>


### PR DESCRIPTION
New machine-learning for Immich support AVX CPU. We can remove the warning.